### PR TITLE
ncm-opennebula: do not use qxl video driver

### DIFF
--- a/ncm-opennebula/src/main/resources/raw_level1.tt
+++ b/ncm-opennebula/src/main/resources/raw_level1.tt
@@ -1,6 +1,5 @@
 DATA = "<vcpu>[% vcpus %]</vcpu><cpu mode='host-passthrough'>
 <topology sockets='[% sockets %]' cores='[% cores %]' threads='1'/></cpu>
-<devices><video><model type='qxl'/></video></devices>
 [%- IF system.opennebula.memorybacking.defined %]
 <memoryBacking>
 [%-     FOREACH item IN system.opennebula.memorybacking %]

--- a/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/vm_template
+++ b/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/vm_template
@@ -60,7 +60,6 @@ multiline
 ^RAW\s?=\s?\[$
 ^\s{4}DATA\s?=\s?"\<vcpu\>4\<\/vcpu\>\<cpu\s{1}mode\=\'host-passthrough\'\>$
 ^\s{4}\<topology\s{1}sockets\=\'2\'\s{1}cores\=\'2\'\s{1}threads\=\'1\'\/\>\<\/cpu\>$
-^\s{4}\<devices\>\<video\>\<model\s{1}type\=\'qxl\'\/\>\<\/video\>\<\/devices\>$
 ^\s{4}\<memoryBacking\>$
 ^\s{4}\<nosharepages\/\>$
 ^\s{4}\<hugepages\/\>$

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -908,7 +908,6 @@ OS = [
 RAW = [
     DATA = "<vcpu>4</vcpu><cpu mode='host-passthrough'>
     <topology sockets='2' cores='2' threads='1'/></cpu>
-    <devices><video><model type='qxl'/></video></devices>
     <memoryBacking>
     <nosharepages/>
     <hugepages/>


### PR DESCRIPTION
qxl is not supported any more in RHEL9 and it should be removed. OpenNebula should use the correct video driver automatically.

Resolves:  #1722

Ensure the title of this pull-request starts with the component name followed by a colon, e.g.
> ncm-example: demonstrate what titles should look like

Describe the change you are making here, in particular we would like to know:

* Why the change is necessary.
* What backwards incompatibility it may introduce.
